### PR TITLE
Update url value to use original request url

### DIFF
--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -51,6 +51,10 @@ func TestPrometheus(t *testing.T) {
 			t.Errorf("expected at least 1, got %d", total)
 		}
 
+		if err := testutil.GatherAndCompare(reg, testy.Snapshot(t), "resty_requests_total"); err != nil {
+			t.Error(err)
+		}
+
 		if total, _ := testutil.GatherAndCount(reg, "resty_request_duration_seconds"); total < 1 {
 			t.Errorf("expected at least 1, got %d", total)
 		}

--- a/testdata/TestPrometheus_after_response
+++ b/testdata/TestPrometheus_after_response
@@ -1,0 +1,3 @@
+# HELP resty_requests_total The number of requests made
+# TYPE resty_requests_total counter
+resty_requests_total{code="200",host="flock.service",method="GET",url="/1"} 1

--- a/testdata/TestPrometheus_error
+++ b/testdata/TestPrometheus_error
@@ -1,0 +1,3 @@
+# HELP resty_requests_total The number of requests made
+# TYPE resty_requests_total counter
+resty_requests_total{code="0",host="flock.service",method="GET",url="/1"} 1

--- a/testdata/TestPrometheus_path_params
+++ b/testdata/TestPrometheus_path_params
@@ -1,0 +1,3 @@
+# HELP resty_requests_total The number of requests made
+# TYPE resty_requests_total counter
+resty_requests_total{code="200",host="flock.service",method="GET",url="/{id}"} 1


### PR DESCRIPTION
To avoid multiples unique values in prometheus, was collected the original rul from resty request before the transformation and setup inside the context to be used in the after middleware.